### PR TITLE
OSX fix for `outputclue.sh` on `tree` branch

### DIFF
--- a/outputclue.sh
+++ b/outputclue.sh
@@ -13,13 +13,13 @@ if [ "$file" = "nextclue_input.cpp" ];then
   if [ ${merges} ]; then 
     while read p; do 
       for w in $p;do 
-        if [ `echo $w | md5sum | awk '{print $1}'` = $bug ];then 
+        if [ `echo $w | md5 | awk '{print $1}'` = $bug ];then 
           echo -e $mesg; 
           exit; 
         fi; 
       done;
     done < $file ;
-    echo -e "Well, congratulations!! You fixed my conflict!!\nIf you would like to continue, then you should checkout to the $(echo bW91c2UK | base64 -d) branch!!\n" ;
+    echo -e "Well, congratulations!! You fixed my conflict!!\nIf you would like to continue, then you should checkout to the $(echo bW91c2UK | openssl base64 -d) branch!!\n" ;
    else 
      echo -e $mesg; 
      exit;


### PR DESCRIPTION
This was a fun game, thank you for making it!

Using OSX 10.6.8, I had to change `outputclue.sh` on the `tree` branch to find the next clue. Namely:

* Changing `md5sum` to `md5`
* Changing `base64 -d` to `openssl base64 -d`

I am not able to test these changes on any other operating systems.