### PR TITLE
OSX compatibility -- use openssl md5/base64 in outputclue.sh on tree branch

### DIFF
--- a/outputclue.sh
+++ b/outputclue.sh
@@ -13,13 +13,13 @@ if [ "$file" = "nextclue_input.cpp" ];then
   if [ ${merges} ]; then 
     while read p; do 
       for w in $p;do 
-        if [ `echo $w | md5sum | awk '{print $1}'` = $bug ];then 
+        if [ `echo $w | openssl md5 | awk '{print $1}'` = $bug ];then 
           echo -e $mesg; 
           exit; 
         fi; 
       done;
     done < $file ;
-    echo -e "Well, congratulations!! You fixed my conflict!!\nIf you would like to continue, then you should checkout to the $(echo bW91c2UK | base64 -d) branch!!\n" ;
+    echo -e "Well, congratulations!! You fixed my conflict!!\nIf you would like to continue, then you should checkout to the $(echo bW91c2UK | openssl base64 -d) branch!!\n" ;
    else 
      echo -e $mesg; 
      exit;


### PR DESCRIPTION
This is an improvement on pull request #10 thanks to @riqpe's suggestion but keeping `awk '{print $1}'`.

This works on OSX. I am not able to test this on Linux.