### PR TITLE
outputclue.sh fix for tree branch -- use openssl md5/base64 and grep

### DIFF
--- a/outputclue.sh
+++ b/outputclue.sh
@@ -13,13 +13,13 @@ if [ "$file" = "nextclue_input.cpp" ];then
   if [ ${merges} ]; then 
     while read p; do 
       for w in $p;do 
-        if [ `echo $w | md5sum | awk '{print $1}'` = $bug ];then 
+        if [ `echo $w | openssl md5 | grep $bug` ];then 
           echo -e $mesg; 
           exit; 
         fi; 
       done;
     done < $file ;
-    echo -e "Well, congratulations!! You fixed my conflict!!\nIf you would like to continue, then you should checkout to the $(echo bW91c2UK | base64 -d) branch!!\n" ;
+    echo -e "Well, congratulations!! You fixed my conflict!!\nIf you would like to continue, then you should checkout to the $(echo bW91c2UK | openssl base64 -d) branch!!\n" ;
    else 
      echo -e $mesg; 
      exit;


### PR DESCRIPTION
It seems that [OSX and Linux implement the `awk` command differently](https://stackoverflow.com/questions/24332942/why-awk-script-does-not-work-on-mac-os-but-works-on-linux).

This pull request still uses `openssl md5` and `openssl base64 -d` per requests #10 and #11, but uses `grep` instead of `awk` for matching `$bug`.

Tested on OSX. Please test on Linux before merging. Thank you!