### PR TITLE
fix OSTYPE check for yosemite

### DIFF
--- a/outputclue.sh
+++ b/outputclue.sh
@@ -10,7 +10,7 @@ mesg="Linus has been here...\nI love messing with these amateur programmers!!\nI
 merges=$(git log --format=%h --merges | head -1)
 csum="md5sum"
 b64="base64 -d"
-if [[ "$OSTYPE" = "darwin" ]];then
+if [[ "$OSTYPE" =~ ^darwin* ]];then
     csum="md5"
     b64="base64 -D"
 fi


### PR DESCRIPTION
Thanks for the `git` game.

I have fixed #17 (and propably #16) with this little change.
I also tried to play the `hub` game with [https://hub.github.com](https://hub.github.com)

```bash
hub clone hgarc014/git-game
cd git-game/
git remote -v
git checkout tree
git checkout -b fix_for_yosemite
vi outputclue.sh 
git add .
git commit -m "fix OSTYPE check for yosemite"
hub fork
hub push StefanScherer fix_for_yosemite
hub pull-request
```

But the last one didn't work. But I also have to create the PR against your `tree` branch.
