### PR TITLE
make `outputclue.sh` compatible with msysgit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Normally, when ran with the shell script "outputclue.sh", the "nextclue_input.cp
 
 Maybe, you should try running the shell script with the "nextclue_input.cpp" file and see what happens...
 
-You can run the script by running the command "./outputclue.sh FILE"
-If you are on Windows, then you will need to use Cygwin.
+You can run the script by running the command "./outputclue.sh FILE" .
+If you are on Windows, it's okey to use `git-bash` that is installed with [msysgit](https://msysgit.github.io/).
 

--- a/outputclue.sh
+++ b/outputclue.sh
@@ -9,10 +9,8 @@ bug=7c85d987a917c2a555d1391426978f05
 mesg="Linus has been here...\nI love messing with these amateur programmers!!\nIf you want some real fun, then you should try resolving a conflict between this branch (tree) and code4life.\nI introduced a little bug that you should fix in the conflict. >:)\nAfter you merge these 2 files you should run the shell script again!!\n\nGood Luck!!!"
 merges=$(git log --format=%h --merges | head -1)
 csum="md5sum"
-b64="base64 -d"
-if [[ "$OSTYPE" =~ ^darwin* ]];then
+if [ $(echo "$OSTYPE" | grep darwin) ];then
     csum="md5"
-    b64="base64 -D"
 fi
 
 if [ "$file" = "nextclue_input.cpp" ];then 
@@ -25,7 +23,7 @@ if [ "$file" = "nextclue_input.cpp" ];then
         fi; 
       done;
     done < $file ;
-    echo -e "Well, congratulations!! You fixed my conflict!!\nIf you would like to continue, then you should checkout to the $(echo bW91c2UK | $b64 ) branch!!\n" ;
+    echo -e "Well, congratulations!! You fixed my conflict!!\nIf you would like to continue, then you should checkout to the $(echo 90mP8ouQHsNe | tr -d '0-9A-Z') branch!!\n" ;
    else 
      echo -e $mesg; 
      exit;


### PR DESCRIPTION
make `outputclue.sh` compatible with msysgit to make it work on Windows
    
     1. use `grep` for the regex matching, since the bash (version 3.1) in msysgit
        dose not support `=~` expression
     2. use `tr` for the simple encryption, since `base64` does not exist
     3. update README
